### PR TITLE
Resolve security warning by using jackson 2.10.2, not 2.4.0

### DIFF
--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -12,7 +12,7 @@
     <name>UIThemes: Processor</name>
 
     <properties>
-        <jackson.version>2.4.0</jackson.version>
+        <jackson.version>2.10.2</jackson.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Resolve jackson 2.4.0 security warning

GitHub reports that there is a critical security alert in the com.fasterxml.jackson.core:jackson-databind 2.4.0 component that is included in this repository.  We need to upgrade to at least 2.6.7.1.  This pull request updates to the most recent release of jackson.

Either we need to merge this pull request to remove the GitHub security warning or we need to remove this repository from the jenkinsci org.  I see no indication of any release of this plugin being pushed to the Jenkins update center or to artifactory.  I would prefer that we delete the repository so that jenkinsci administrators do not need to see the warning related to security.